### PR TITLE
Add Dota Underlords as a game

### DIFF
--- a/config/data_config.json
+++ b/config/data_config.json
@@ -146,6 +146,29 @@
           }
         ]
       }
+    },
+    {
+      "name": "underlords",
+      "label": "Dota Underlords",
+      "aliases": [
+        "underlords",
+        "dota underlords",
+        "du"
+      ],
+      "color": "#FFFFFF",
+      "icon": "https://pbs.twimg.com/profile_images/1139243347237691392/PzgWEKp7_400x400.png",
+      "providers": {
+        "reddit": {
+          "subreddit": "underlords",
+          "users": [
+            {
+              "name": "wykrhm",
+              "titleFilter": ""
+            }
+          ]
+        },
+        "blogs": []
+      }
     }
   ]
 }


### PR DESCRIPTION
Adds Dota Underlords as a game.
Sources:
- /u/wykrhm on /r/underlords

Fix #65.