### PR TITLE
Fix Steam icon not displaying

### DIFF
--- a/config/data_config.json
+++ b/config/data_config.json
@@ -128,7 +128,7 @@
         "steam"
       ],
       "color": "#0B5A8E",
-      "icon": "https://upload.wikimedia.org/wikipedia/commons/8/83/Steam_icon_logo.svg",
+      "icon": "https://pbs.twimg.com/profile_images/887778636102721536/Nxgl7xz4_400x400.jpg",
       "providers": {
         "reddit": {
           "subreddit": "Steam",


### PR DESCRIPTION
Fix Steam icon not displaying.
We now use the Twitter avatar of @steam_games.